### PR TITLE
Revert "Updated Student Task Submission"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ Attention to Detail: The expectation is to assess the employee's attention to de
 
 Students are expected to use the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) when working on their project. 
 
-1. Using [GitHub Classroom](https://classroom.github.com/) to make submissions
+1. Creating a new branch.
 
-2. Opening a Pull Request for review
+2. Opening a Pull Request for review and submission.
 
 3. Using GitHub Discussions to ask any relevant questions regarding the project
 
 | Octernship info  | Timelines and Stipend |
 | ------------- | ------------- |
-| Assignment Deadline  | 20 March 2023  |
+| Assignment Deadline  | 27 March 2023  |
 | Octernship Duration  | 4 Months  |
 | Monthly Stipend  | $500 USD  |
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ Attention to Detail: The expectation is to assess the employee's attention to de
 
 Students are expected to use the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) when working on their project. 
 
-1. Making changes on the auto generated `feedback` branch to complete the task
-2. Using the auto generated **Feedback Pull Request** for review and submission
+1. Using [GitHub Classroom](https://classroom.github.com/) to make submissions
+
+2. Opening a Pull Request for review
+
 3. Using GitHub Discussions to ask any relevant questions regarding the project
 
 | Octernship info  | Timelines and Stipend |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Students are expected to use the [GitHub Flow](https://docs.github.com/en/get-st
 
 | Octernship info  | Timelines and Stipend |
 | ------------- | ------------- |
-| Assignment Deadline  | 27 March 2023  |
+| Assignment Deadline  | 20 March 2023  |
 | Octernship Duration  | 4 Months  |
 | Monthly Stipend  | $500 USD  |
 


### PR DESCRIPTION
Reverts Gari-Dev-DAO/Octernship_design_assignment#1

Reason: From students' feedback, they find it confusing to work from an autogenerated branch/PR, and hence **they can create a new branch/PR to submit Octernship Assignment**. 
- Maintainers can still use the feedback PR to provide feedback for any changes on `main`.
- We are still recommending students follow the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow#following-github-flow) for better workflow.